### PR TITLE
Fix missing imports and view signature

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -12,6 +12,6 @@ def get_csrf_token(request):
     """Απλό view που ενεργοποιεί το CSRF cookie"""
     return JsonResponse({"message": "CSRF cookie set"})
 
-def api_root():
+def api_root(request):
     """Προαιρετικό root endpoint της API"""
     return JsonResponse({"message": "Welcome to the API root."})

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,5 +1,5 @@
 import factory
-from django.contrib.auth import get_user_model  # type: ignore  # type: ignore  # type: ignore
+from django.contrib.auth import get_user_model
 from buildings.models import Building
 from user_requests.models import UserRequest
 from announcements.models import Announcement
@@ -54,4 +54,5 @@ class AnnouncementFactory(factory.django.DjangoModelFactory):
     end_date = "2025-05-31"
     published = True
     created_by = factory.SubFactory(UserFactory)
+    building = factory.SubFactory(BuildingFactory)
     building = factory.SubFactory(BuildingFactory)

--- a/backend/tests/test_announcements.py
+++ b/backend/tests/test_announcements.py
@@ -1,6 +1,6 @@
 import pytest
 from rest_framework.test import APIClient
-from django.urls import reverse  # type: ignore  # type: ignore  # type: ignore
+from django.urls import reverse
 from tests.factories import UserFactory, AnnouncementFactory
 
 @pytest.mark.django_db
@@ -26,4 +26,5 @@ def test_list_announcements():
     client = APIClient()
     response = client.get(reverse("announcement-list"))
     assert response.status_code == 200
+    assert len(response.data["results"]) == 3
     assert len(response.data["results"]) == 3

--- a/backend/tests/test_user_requests.py
+++ b/backend/tests/test_user_requests.py
@@ -1,7 +1,7 @@
 # backend/tests/test_user_requests.py
 
 import pytest
-from django.urls import reverse  # type: ignore  # type: ignore  # type: ignore
+from django.urls import reverse
 from rest_framework.test import APIClient
 from user_requests.models import UserRequest
 from tests.factories import UserFactory, UserRequestFactory, BuildingFactory
@@ -59,5 +59,6 @@ def test_list_user_requests(auth_client, user):
 
     response = auth_client.get(reverse("userrequest-list"))
     assert response.status_code == 200
+    assert len(response.data["results"]) == 1
     assert len(response.data["results"]) == 1
     assert response.data["results"][0]["title"] == "A"  


### PR DESCRIPTION
## Summary
- remove stray Windows line endings and fix import statements
- fix `api_root` view signature to accept `request`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68402e541144832fab9e7ed7b98a1c8c